### PR TITLE
Upload iOS release builds to artifactory

### DIFF
--- a/.github/workflows/android-build-release.yml
+++ b/.github/workflows/android-build-release.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Push build to Artifactory
         run: |
           export JFROG_CLI_LOG_LEVEL=DEBUG
-          jf rt upload ${{ steps.sign_app.outputs.signedReleaseFile }} ${{ vars.ARTIFACTORY_REPO_NAME }}
+          jf rt upload ${{ steps.sign_app.outputs.signedReleaseFile }} "${{ vars.ARTIFACTORY_REPO_NAME }}/SecureImage-android-${{ github.run_number }}.apk"

--- a/.github/workflows/android-build-release.yml
+++ b/.github/workflows/android-build-release.yml
@@ -42,9 +42,16 @@ jobs:
           keyPassword: ${{ secrets.ANDROID_KEYPW }}
         env:
           BUILD_TOOLS_VERSION: "33.0.0"
-      
-      - name: Upload release artifact
-        uses: actions/upload-artifact@v3.1.2
-        with:
-          name: SecureImage-release-signed
-          path: ${{ steps.sign_app.outputs.signedReleaseFile }}
+
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_PROJECT: ${{ vars.ARTIFACTORY_PROJECT }}
+          JF_URL: ${{ vars.ARTIFACTORY_URL }}
+          JF_USER: ${{ secrets.ARTIFACTORY_SERVICE_ACCOUNT_USER }}
+          JF_PASSWORD: ${{ secrets.ARTIFACTORY_SERVICE_ACCOUNT_PWD }}
+
+      - name: Push build to Artifactory
+        run: |
+          export JFROG_CLI_LOG_LEVEL=DEBUG
+          jf rt upload ${{ steps.sign_app.outputs.signedReleaseFile }} ${{ vars.ARTIFACTORY_REPO_NAME }}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -59,10 +59,16 @@ jobs:
       # here we use the specification in ios/exportOptions-adhoc.plist file to describe how the code is signed and should be exported.
       - name: Export .ipa
         run: ./.github/scripts/export_ios_ipa.sh
-      # uploads the generated .ipa file using actions/upload-artifact@v1
-      - name: Upload .ipa
-        uses: actions/upload-artifact@v1
-        with:
-          name: SecureImage.ipa
-          path: build/Apps/SecureImage.ipa
+      # uploads the generated .ipa file to a gov-hosted Artifactory instance
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_PROJECT: ${{ vars.ARTIFACTORY_PROJECT }}
+          JF_URL: ${{ vars.ARTIFACTORY_URL }}
+          JF_USER: ${{ secrets.ARTIFACTORY_SERVICE_ACCOUNT_USER }}
+          JF_PASSWORD: ${{ secrets.ARTIFACTORY_SERVICE_ACCOUNT_PWD }}
+      - name: Push build to Artifactory
+        run: |
+          export JFROG_CLI_LOG_LEVEL=DEBUG
+          jf rt upload build/Apps/SecureImage.ipa ${{ vars.ARTIFACTORY_REPO_NAME }}
           

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -70,5 +70,5 @@ jobs:
       - name: Push build to Artifactory
         run: |
           export JFROG_CLI_LOG_LEVEL=DEBUG
-          jf rt upload build/Apps/SecureImage.ipa ${{ vars.ARTIFACTORY_REPO_NAME }}
+          jf rt upload build/Apps/SecureImage.ipa "${{ vars.ARTIFACTORY_REPO_NAME }}/SecureImage-ios-${{ github.run_number }}.ipa"
           


### PR DESCRIPTION
OCIO has asked us to deploy app builds to their Artifactory instance instead of GH artifacts.